### PR TITLE
Cast draw.circle coordinates to int in clear func

### DIFF
--- a/GoblinEscape.py
+++ b/GoblinEscape.py
@@ -26,8 +26,8 @@ def clear():
 	radius_mult = bspeed / gspeeds[gspeed_ix]
 
 	window.fill((0,80,0))
-	pygame.draw.circle(window, (0,0,128), (width/2, height/2), int(radius*1.00), 0)
-	pygame.draw.circle(window, (200,200,200), (width/2, height/2), int(radius*radius_mult), 1)
+	pygame.draw.circle(window, (0,0,128), (int(width/2), int(height/2)), int(radius*1.00), 0)
+	pygame.draw.circle(window, (200,200,200), (int(width/2), int(height/2)), int(radius*radius_mult), 1)
 
 def redraw(draw_text=False,win=False):
 	clear()


### PR DESCRIPTION
Unsure if it is Python 3 or new pygame version that is causing the
error to appear but solution is simple and in-line with other code
in the repository. Shouldn't break Python 2 compatibility either.