### PR TITLE
Fix bug- changing levels and exit game

### DIFF
--- a/GoblinEscape.py
+++ b/GoblinEscape.py
@@ -19,6 +19,7 @@ def restart():
 	boatx = 0.1
 	boaty = 0.0
 	clicking = False
+	actual_level = 1
 
 pygame.init()
 window = pygame.display.set_mode((width, height))

--- a/GoblinEscape.py
+++ b/GoblinEscape.py
@@ -1,26 +1,27 @@
 import pygame, sys, math
-	
+
 width = 1024
 height = 720
 radius = 300.0
 goblin = 0.0
-boatx = 0.1 
+boatx = 0.1
 boaty = 0.0
 bspeed = 1.0
 gspeeds = [3.5, 4.0, 4.2, 4.4, 4.6]
 gspeed_ix = 0
 speed_mult = 3.0
 clicking = False
+actual_level = 1
 
 def restart():
 	global goblin, boatx, boaty, clicking
 	goblin = 0.0
-	boatx = 0.1 
+	boatx = 0.1
 	boaty = 0.0
 	clicking = False
 
 pygame.init()
-window = pygame.display.set_mode((width, height)) 
+window = pygame.display.set_mode((width, height))
 
 def clear():
 	radius_mult = bspeed / gspeeds[gspeed_ix]
@@ -52,7 +53,7 @@ def redraw(draw_text=False,win=False):
 	textpos.centerx = width/2
 	textpos.centery = height - 20
 	window.blit(text, textpos)
-		
+
 	pygame.display.flip()
 
 def updateGoblin():
@@ -67,7 +68,7 @@ def updateGoblin():
 	else:
 		goblin += gspeed * speed_mult / radius if diff > 0.0 else -gspeed * speed_mult / radius
 	if goblin < math.pi: goblin += math.pi*2.0
-	if goblin > math.pi: goblin -= math.pi*2.0 
+	if goblin > math.pi: goblin -= math.pi*2.0
 
 def moveBoat(x,y):
 	global boatx, boaty
@@ -79,10 +80,11 @@ def moveBoat(x,y):
 		boaty = y
 	else:
 		boatx += bspeed * speed_mult * dx/mag
-		boaty += bspeed * speed_mult * dy/mag 
-	
+		boaty += bspeed * speed_mult * dy/mag
+
 def detectWin():
 	global gspeed_ix
+	global actual_level
 	if boatx*boatx + boaty*boaty > radius*radius:
 		diff = math.atan2(boaty, boatx) - goblin
 		if diff < math.pi: diff += math.pi*2.0
@@ -91,20 +93,21 @@ def detectWin():
 			is_win = abs(diff) > 0.000001
 			redraw(True, is_win)
 			events = [event.type for event in pygame.event.get()]
-			if pygame.QUIT in events: 
+			if pygame.QUIT in events:
 				sys.exit(0)
 			elif pygame.MOUSEBUTTONDOWN in events:
 				restart()
 				if is_win:
 					gspeed_ix += 1
+					actual_level += 1
 				break
 
 clock = pygame.time.Clock()
 clear()
 while True:
 	x = None
-	for event in pygame.event.get(): 
-		if event.type == pygame.QUIT: 
+	for event in pygame.event.get():
+		if event.type == pygame.QUIT:
 			sys.exit(0)
 		clicking = pygame.mouse.get_pressed()[0]
 		if pygame.mouse.get_pressed()[2]:
@@ -115,5 +118,8 @@ while True:
 		moveBoat(x - width/2, y - height/2)
 	updateGoblin()
 	detectWin()
+	if actual_level == len(gspeeds):
+		break
 	redraw()
 	clock.tick(60)
+sys.exit(0)

--- a/GoblinEscape.py
+++ b/GoblinEscape.py
@@ -14,7 +14,7 @@ clicking = False
 actual_level = 1
 
 def restart():
-	global goblin, boatx, boaty, clicking
+	global goblin, boatx, boaty, clicking, actual_level
 	goblin = 0.0
 	boatx = 0.1
 	boaty = 0.0


### PR DESCRIPTION
Added a level counter that exits the game when it wins the final level.
Before this patch, when you get past the final level, if you can, where the speed of the goblin is 4.6 the game crashes because it tries to get the next speed of the goblin in ```gspeeds``` and this causes an _Index error_.